### PR TITLE
Allow devs to customize buyer name in order list

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -172,6 +172,8 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 			$user  = get_user_by( 'id', $this->object->get_customer_id() );
 			$buyer = ucwords( $user->display_name );
 		}
+		
+		$buyer = apply_filters( 'woocommerce_render_order_number_buyer', $buyer, $this->object );
 
 		if ( $this->object->get_status() === 'trash' ) {
 			echo '<strong>#' . esc_attr( $this->object->get_order_number() ) . ' ' . esc_html( $buyer ) . '</strong>';


### PR DESCRIPTION
Allows devs to change default billing first/last name for order list in wp-admin to another of their choosing via filter.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A client has requested the ability to change the billing first/last name in the back-end order list to customer first/last name.

This change was not possible without editing WooCommerce files directly so a filter has been proposed which will enable this customization.

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Buyer names can now be customized in the order list using the filter `woocommerce_render_order_number_column_buyer`
